### PR TITLE
run.log文件未及时生成时，tail命令会报文件找不到的错误

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,6 +5,7 @@ if [[ ! -e /etc/v2ray ]];then
     v2ray new >/dev/null 2>&1
 fi
 
+touch /.run.log
 /usr/bin/v2ray/v2ray -config=/etc/v2ray/config.json > /.run.log &
 
 tail -f /.run.log


### PR DESCRIPTION
/usr/bin/v2ray/v2ray -config=/etc/v2ray/config.json > /.run.log &命令后台运行，很大几率启动时还没开始打日志，此时tail日志文件则报不存在，比较烦人。