### PR TITLE
Fix trojan share problem.

### DIFF
--- a/v2ray_util/util_core/group.py
+++ b/v2ray_util/util_core/group.py
@@ -66,7 +66,7 @@ class Trojan(User):
             return "Password: {password}\n".format(password=self.password)
 
     def link(self, ip, port, tls):
-        return ColorStr.green("trojan://{0}@{1}:{2}".format(self.password, ip, port))
+        return ColorStr.green("trojan://{0}@{1}:{2}#{1}:{2}".format(self.password, ip, port))
 
     def stream(self):
         return "trojan"


### PR DESCRIPTION
To Improve the format of Trojan share links In order to adapt to the link import of V2RayNG.
For questions about trojan sharing links,see #581 
and sorry for the previous mistake of submitting the file on #582.